### PR TITLE
Swap randsize & dist conditionals

### DIFF
--- a/cli/generator.go
+++ b/cli/generator.go
@@ -111,21 +111,21 @@ func validateGeneratorFlags(ctx *cli.Context) {
 
 // applies generators based on the randomization option provided.
 func applyGenerators(g generator.OptionApplier, ctx *cli.Context, prefixSize int, size uint64) (func() generator.Source, error) {
-	if ctx.Bool("obj.randsize") {
-		src, err := generator.NewFn(g.Apply(),
-			generator.WithCustomPrefix(ctx.String("prefix")),
-			generator.WithPrefixSize(prefixSize),
-			generator.WithSize(int64(size)),
-			generator.WithRandomSize(ctx.Bool("obj.randsize")),
-		)
-		return src, err
-	} else {
+	if ctx.String("obj.dist") != "" {
 		sizesArr := parseDisrtibutionSizes(ctx)
 
 		src, err := generator.NewFn(g.Apply(),
 			generator.WithCustomPrefix(ctx.String("prefix")),
 			generator.WithPrefixSize(prefixSize),
 			generator.WithSizeDistribution(sizesArr),
+		)
+		return src, err
+	} else {
+		src, err := generator.NewFn(g.Apply(),
+			generator.WithCustomPrefix(ctx.String("prefix")),
+			generator.WithPrefixSize(prefixSize),
+			generator.WithSize(int64(size)),
+			generator.WithRandomSize(ctx.Bool("obj.randsize")),
 		)
 		return src, err
 	}


### PR DESCRIPTION
Ran tests without any options specified, with randsize and with dist. All of them succeeded.

No option specified -
```
$ go run main.go put --access-key minioadmin --secret-key minioadmin --duration 30s --obj.size 4MiB --concurrent 1
main: Benchmark data written to "warp-put-2022-11-16[162048]-E7UU.csv.zst"

----------------------------------------
Operation: PUT
* Average: 48.06 MiB/s, 12.01 obj/s

Throughput, split into 29 x 1s:
 * Fastest: 54.0MiB/s, 13.50 obj/s
 * 50% Median: 50.9MiB/s, 12.72 obj/s
 * Slowest: 18.4MiB/s, 4.60 obj/s
main: Cleanup Done.
```

With randsize -
```
$ go run main.go put --access-key minioadmin --secret-key minioadmin --duration 30s --obj.randsize --obj.size 4MiB --c
main: Benchmark data written to "warp-put-2022-11-16[162358]-99Te.csv.zst"

----------------------------------------
Operation: PUT
* Average: 34.77 MiB/s, 50.79 obj/s

Throughput, split into 29 x 1s:
 * Fastest: 42.7MiB/s, 47.87 obj/s
 * 50% Median: 38.8MiB/s, 59.40 obj/s
 * Slowest: 3.0MiB/s, 2.48 obj/s
main: Cleanup Done.
```

With dist -
```
$ go run main.go put --access-key minioadmin --secret-key minioadmin --duration 30s --obj.dist 1KB:10,4KB:15,8KB:15,16KB:15,32KB:15,64KB:10,128KB:5,256KB:10,1MB:5 --concurrent 1
main: Benchmark data written to "warp-put-2022-11-16[162605]-PiGX.csv.zst"

----------------------------------------
Operation: PUT
* Average: 12.55 MiB/s, 128.55 obj/s

Throughput, split into 29 x 1s:
 * Fastest: 18.0MiB/s, 128.09 obj/s
 * 50% Median: 12.4MiB/s, 115.96 obj/s
 * Slowest: 9.2MiB/s, 126.82 obj/s
main: Cleanup Done.
```