### PR TITLE
Resetting buffer size

### DIFF
--- a/pkg/generator/csv.go
+++ b/pkg/generator/csv.go
@@ -149,7 +149,7 @@ func (c *csvSource) Object() *Object {
 		}
 	}
 	c.buf.data = dst
-	c.obj.Reader = c.buf.Reset(0)
+	c.obj.Reader = c.buf.Reset(c.obj.Size)
 	var nBuf [16]byte
 	randASCIIBytes(nBuf[:], c.rng)
 	c.obj.setName(string(nBuf[:]) + ".csv")


### PR DESCRIPTION
Providing the `randsize` option with CSV was causing errors as the actual body length was not matching the Content-Length HTTP header. The issue was the buffer size was being set to zero when it should have been set to the size of the object.

Tested the changes will single object size and random size options and both succeeded.